### PR TITLE
Modify Govee LED strip

### DIFF
--- a/devices/devices.json
+++ b/devices/devices.json
@@ -404,7 +404,7 @@
   },
   {
     "image": "product_images/govee_strip.webp",
-    "product": "Govee LED Strip Light",
+    "product": "Govee LED Strip Light M1",
     "manufacturer": "Govee",
     "certification_id": "Certificate ID: CSA23584MAT41097-24",
     "certification_link": "https://csa-iot.org/csa_product/govee-led-strip-light-8/",
@@ -414,7 +414,9 @@
     "supportsBluetooth": true,
     "display": true,
     "note": "",
-    "buyLinks": [],
+    "buyLinks": [
+      "https://us.govee.com/products/govee-led-strip-light-m1-matter-compatible"
+    ],
     "available": true,
     "ean": "6974316992608"
   },

--- a/devices/devices.json
+++ b/devices/devices.json
@@ -415,7 +415,8 @@
     "display": true,
     "note": "",
     "buyLinks": [
-      "https://us.govee.com/products/govee-led-strip-light-m1-matter-compatible"
+      "https://us.govee.com/products/govee-led-strip-light-m1-matter-compatible",
+      "https://www.amazon.com/Govee-Cabinet-Assistant-SmartThings-Upgraded/dp/B0BWLHHV8M"
     ],
     "available": true,
     "ean": "6974316992608"


### PR DESCRIPTION
Govee LED M1 strips before 2023 did not support matter. All new M1 strips do suport matter as of summer 2023

## Changes

- Includes 'm1' in the name, because there are many flavors of Govee LED strips, not all support matter
- Add link to US store

